### PR TITLE
Separate doc filtration and reasoning LLMs

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -37,6 +37,7 @@ Initialize the client by providing required configuration options:
 ```typescript
 client = new ReagClient(
   model: "o3-mini", // LiteLLM model name
+  filtration_model: "minimax", // Filtration model name
   system: Optional[str] // Optional system prompt
   batchSize: Optional[Number] // Optional batch size
   schema: Optional[BaseModel] // Optional Pydantic schema

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -21,6 +21,7 @@ import { openai } from "@ai-sdk/openai";
 // Initialize the SDK with required options
 const client = new ReagClient({
   model: openai("o3-mini", { structuredOutputs: true }),
+  filtrationModel: openai("minimax", { structuredOutputs: true }),
   // system: optional system prompt here or use the default
 });
 
@@ -62,6 +63,7 @@ Initialize the client by providing required configuration options:
 ```typescript
 const client = new ReagClient({
   model: openai("o3-mini", { structuredOutputs: true }),
+  filtrationModel: openai("minimax", { structuredOutputs: true }),
   system?: string // Optional system prompt
   batchSize?: number // Optional batch size
   schema?: z.ZodSchema // Optional schema


### PR DESCRIPTION
Fixes #1

Separate the document filtration and reasoning LLMs into two distinct models.

* **Python Changes:**
  - Add a new parameter `filtration_model` to the `ReagClient` constructor in `python/src/reag/client.py`.
  - Update the `query` method to use the `filtration_model` for document filtration and the `model` for generating the final answer.
  - Update `python/README.md` to reflect the changes in the `ReagClient` class and the new two-step process.

* **TypeScript Changes:**
  - Add a new parameter `filtrationModel` to the `ReagClient` constructor in `typescript/src/client.ts`.
  - Update the `query` method to use the `filtrationModel` for document filtration and the `model` for generating the final answer.
  - Update `typescript/README.md` to reflect the changes in the `ReagClient` class and the new two-step process.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/superagent-ai/reag/issues/1?shareId=XXXX-XXXX-XXXX-XXXX).