### PR TITLE
fix issue with early returns in python sdk

### DIFF
--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from src.reag.client import ReagClient, Document, QueryResult
+from reag.client import ReagClient, Document, QueryResult
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request includes several changes to the `python/src/reag/client.py` file to improve the parallel processing of document batches and minor adjustments in the `python/tests/test_client.py` file. The most important changes include adding asynchronous processing for document batches and reorganizing the return statement for clarity.

Improvements to parallel processing:

* [`python/src/reag/client.py`](diffhunk://#diff-df35b0640452982f29776c377fd1684e6713860849b9cd82188db5f3eac65c54R159-R179): Added tasks for parallel processing within the batch and used `asyncio.gather` to process all documents in the batch concurrently. This change improves the efficiency of handling document batches.

Code organization and readability:

* [`python/src/reag/client.py`](diffhunk://#diff-df35b0640452982f29776c377fd1684e6713860849b9cd82188db5f3eac65c54L193-R204): Moved the return statement outside the batch loop to ensure all results are returned after processing all batches. This change clarifies the flow of the function.

Minor code adjustments:

* [`python/tests/test_client.py`](diffhunk://#diff-32ec56c5e4ff6a773f4b3c623658f168b7ee48095ba8db0cac59768013f70e45L2-R2): Fixed the import statement to correctly import `ReagClient`, `Document`, and `QueryResult` from `reag.client` instead of `src.reag.client`.