### PR TITLE
New Feature: Ollama support for reasoning models

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -13,8 +13,9 @@
 ```python
 from reag.client import ReagClient, Document
 
-
- async with ReagClient() as client:
+async with ReagClient(
+      model="ollama/deepseek-r1:14b",
+      api_base="http://localhost:11434") as client:
         docs = [
             Document(
                 name="Superagent",
@@ -36,7 +37,7 @@ Initialize the client by providing required configuration options:
 
 ```typescript
 client = new ReagClient(
-  model: "o3-mini", // LiteLLM model name
+  model: "gpt-4o-mini", // LiteLLM model name
   system: Optional[str] // Optional system prompt
   batchSize: Optional[Number] // Optional batch size
   schema: Optional[BaseModel] // Optional Pydantic schema

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -29,6 +29,7 @@ python = ">=3.9,<3.13"
 pydantic = "^2.0.0"
 httpx = "^0.25.0"
 litellm = "^1.60.0"
+ollama = "0.3.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
## Overview
This PR adds Ollama support and enhances response parsing capabilities for different model outputs. Fixes #6 

Adding Ollama support to ReAG by enhancing the ReagClient class to support local model inference and improving response parsing.

## Changes Made
1. Enhanced `ReagClient` initialization:
   - Added optional `api_base` parameter for Ollama support
   - Maintained backward compatibility with existing implementation

2. Added response parsing improvements:
   - New `_extract_think_content` method to handle DeepSeek models' markdown responses
   - Added fallback parsing for responses using think tags
   - Enhanced error handling in the query method

## Environment
- Python: 3.11.3
- ReAG version: 0.0.3
- Ollama version: 0.3.1

## Implementation Details
The implementation adds support for:
- Custom API base URLs for Ollama endpoints
- Parsing both JSON and tagged format responses
- Maintaining existing functionality while adding Ollama support

## Example Usage
```python
from reag.client import ReagClient, Document

async with ReagClient(
    model="ollama/deepseek-r1:14b",
    api_base="http://localhost:11434") as client:
	docs = [
		Document(
			name="Superagent",
			content="Superagent is a workspace for AI-agents that learn, perform work, and collaborate.",
			metadata={
				"url": "https://superagent.sh",
				"source": "web",
			},
		),
	]
	response = await client.query("What is Superagent?", documents=docs)

```