### PR TITLE
New Feature: model_kwargs for customizing LLM generation parameters

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -14,8 +14,9 @@
 from reag.client import ReagClient, Document
 
 async with ReagClient(
-      model="ollama/deepseek-r1:14b",
-      api_base="http://localhost:11434") as client:
+      model="ollama/deepseek-r1:7b",
+      model_kwargs={"api_base": "http://localhost:11434"}
+   ) as client:
         docs = [
             Document(
                 name="Superagent",

--- a/python/src/reag/client.py
+++ b/python/src/reag/client.py
@@ -42,13 +42,13 @@ class ReagClient:
         system: str = None,
         batch_size: int = DEFAULT_BATCH_SIZE,
         schema: Optional[BaseModel] = None,
-        api_base: Optional[str] = None,  # Added for Ollama support
+        model_kwargs: Optional[Dict] = None,
     ):
         self.model = model
         self.system = system or REAG_SYSTEM_PROMPT
         self.batch_size = batch_size
         self.schema = schema or ResponseSchemaMessage
-        self.api_base = api_base  # New attribute for API base URL
+        self.model_kwargs = model_kwargs or {}
         self._http_client = None
 
     async def __aenter__(self):
@@ -195,6 +195,7 @@ class ReagClient:
                                 {"role": "user", "content": prompt},
                             ],
                             response_format=self.schema,
+                            **self.model_kwargs,
                         )
                     )
 


### PR DESCRIPTION
## Overview
This PR adds model_kwargs support, enhancing LLM parameter customization. Fixes #12 

Adding Ollama support to ReAG by enhancing the ReagClient class to support local model inference and improving response parsing.

## Changes Made
1. Enhanced `ReagClient` initialization:
   - Added `model_kwargs` parameter for fine-grained LLM contro

## Environment
- Python: 3.11.3
- ReAG version: 0.0.4

## Implementation Details
The implementation adds support for:
- Custom model parameters via model_kwargs (temperature, top_p, etc.)

## Example Usage
```python
from reag.client import ReagClient, Document

async with ReagClient(
      model="ollama/deepseek-r1:7b",
      model_kwargs={"api_base": "http://localhost:11434"}
   ) as client:
        docs = [
            Document(
                name="Superagent",
                content="Superagent is a workspace for AI-agents that learn, perform work, and collaborate.",
                metadata={
                    "url": "https://superagent.sh",
                    "source": "web",
                },
            ),
        ]
        response = await client.query("What is Superagent?", documents=docs)
```