### PR TITLE
Fixes Dependency Conflict Reag and Ollama

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -29,7 +29,6 @@ python = ">=3.9,<3.13"
 pydantic = "^2.0.0"
 httpx = "^0.25.0"
 litellm = "^1.60.0"
-ollama = "0.3.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
removed `ollama` from poetry dependencies. Fixes: #14 